### PR TITLE
cd: Temporarily remove deploy job for now

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,18 +43,6 @@ workflows:
                   - "."
           context:
             - gh-ctx
-      - deploy:
-          name: "deploy-staging"
-          environment: "staging"
-          requires:
-            - snapshot-with-goreleaser
-          filters:
-            branches:
-              only:
-                - trunk
-                - staging
-          context:
-            - k8s-ctx
   release-wf:
     jobs:
       - gor/release:


### PR DESCRIPTION
The staging and production environments aren't up yet. For now, removing this job until they are set up.