### PR TITLE
Set timezone for events when submitted

### DIFF
--- a/webapp/controller-events.go
+++ b/webapp/controller-events.go
@@ -185,8 +185,23 @@ func (a *app) eventsNewPost(w http.ResponseWriter, r *http.Request) {
 
 	name := r.Form.Get("event-name")
 	summary := r.Form.Get("event-summary")
+	timezone := r.Form.Get("timezone")
 
-	startTime, err := time.Parse("2006-01-02T15:04", r.Form.Get("start-time"))
+	loc, err := time.LoadLocation(timezone)
+	if err != nil {
+
+		slog.Error("Timezone is not parsable.", "timezone", timezone)
+		session.AddFlash(framework.Flash{
+			framework.FlashFail,
+			"Timezone was not valid.",
+		})
+
+		session.Save(r, w)
+		http.Redirect(w, r, "/events/new", http.StatusFound)
+		return
+	}
+
+	startTime, err := time.ParseInLocation("2006-01-02T15:04", r.Form.Get("start-time"), loc)
 	if err != nil {
 
 		slog.Error("Start time is not parsable.", "start-time", r.Form.Get("start-time"))
@@ -200,7 +215,7 @@ func (a *app) eventsNewPost(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	endTime, err := time.Parse("2006-01-02T15:04", r.Form.Get("end-time"))
+	endTime, err := time.ParseInLocation("2006-01-02T15:04", r.Form.Get("end-time"), loc)
 	if err != nil {
 
 		slog.Error("End time is not parsable.", "end-time", r.Form.Get("end-time"))

--- a/webapp/db/event.go
+++ b/webapp/db/event.go
@@ -112,8 +112,8 @@ func NewEvent(u *User, groupID uint64, name string, startTime, endTime time.Time
 
 	e := initEvent(u.DB)
 	e.Name = name
-	e.StartTime = startTime
-	e.EndTime = endTime
+	e.StartTime = startTime.UTC()
+	e.EndTime = endTime.UTC()
 	e.GroupID = groupID
 	e.Summary = summary
 

--- a/webapp/themes/original/sections/events/new.go.html
+++ b/webapp/themes/original/sections/events/new.go.html
@@ -7,7 +7,7 @@
 		<input name="event-name" type="text" placeholder="for example: April Workshop" required>
 	</div>
 	<div class="input-group required">
-		<label for="start-time">Start Date / Time</label>
+		<label for="start-time">Start Date / Time <i class="fa-xs fa-solid fa-circle-question tooltip" data-fa-transform="up-6" title="The timezone is based on your browser."></i></label>
 		<input name="start-time" type="datetime-local" required>
 	</div>
 	<div class="input-group required">
@@ -19,6 +19,10 @@
 		<textarea name="event-summary"></textarea>
 	</div>
 	<p class="required-warning"><span style="color:red">*</span> required field</p>
+	<input id="timezone" name="timezone" type="hidden">
+	<script type="text/JavaScript">
+		document.getElementById( 'timezone' ).value = Intl.DateTimeFormat().resolvedOptions().timeZone;
+	</script>
 	<input type="submit" class="btn primary" value="Next">
 </form>
 {{ end }}


### PR DESCRIPTION
With this PR, the times provided for an event will be processed with the same timezone as the browser providing the time. In the database, they will be stored as UTC.